### PR TITLE
removed originalDate as it was replaced by publicationDate

### DIFF
--- a/Ejustice (be).js
+++ b/Ejustice (be).js
@@ -89,7 +89,6 @@ function getLawEnacted(lineList){
 			item.nameOfAct = ZU.trimInternal(m[3]);
 			item.nameOfAct = item.nameOfAct.replace(/[\[\]]/g, "");
 			item.nameOfAct = item.nameOfAct.replace(/\.$/, "");
-			item.originalDate = lineList[i].innerHTML.match(/Publicat.*?(\d{2}-\d{2}-\d{4})/)[1];
 			item.publicationDate = lineList[i].innerHTML.match(/Publicat.*?(\d{2}-\d{2}-\d{4})/)[1];
 			Z.debug("Publication Date: " + item.publicationDate);
 			item.pages = lineList[i].innerHTML.match(/"red">\s?(page|bla).*?(\d+)/)[2];


### PR DESCRIPTION
Since commit https://github.com/V-A-collaboration/translators/commit/388b40469639392975e0ab674f79bc7d17da1d41 tests don't expect an originalDate anymore. This PR is to make most tests green again. 2 other tests are still failing because of a wrong regex as pointed out by issue https://github.com/V-A-collaboration/v-en-a/issues/68. A subsequent PR will be submitted if this one is accepted.

